### PR TITLE
chore(ci): use sccache r2 in workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -93,8 +93,8 @@ jobs:
       deployments: write
     env:
       RUSTC_WRAPPER: sccache
-      SCCACHE_BUCKET: ${{ vars.SCCACHE_BUCKET }}
-      SCCACHE_ENDPOINT: ${{ vars.SCCACHE_ENDPOINT }}
+      SCCACHE_BUCKET: ${{ secrets.SCCACHE_BUCKET }}
+      SCCACHE_ENDPOINT: ${{ secrets.SCCACHE_ENDPOINT }}
       SCCACHE_REGION: auto
       SCCACHE_S3_USE_SSL: "true"
       AWS_ACCESS_KEY_ID: ${{ secrets.SCCACHE_AWS_ACCESS_KEY_ID }}
@@ -168,8 +168,8 @@ jobs:
     runs-on: ubuntu-latest
     env:
       RUSTC_WRAPPER: sccache
-      SCCACHE_BUCKET: ${{ vars.SCCACHE_BUCKET }}
-      SCCACHE_ENDPOINT: ${{ vars.SCCACHE_ENDPOINT }}
+      SCCACHE_BUCKET: ${{ secrets.SCCACHE_BUCKET }}
+      SCCACHE_ENDPOINT: ${{ secrets.SCCACHE_ENDPOINT }}
       SCCACHE_REGION: auto
       SCCACHE_S3_USE_SSL: "true"
       AWS_ACCESS_KEY_ID: ${{ secrets.SCCACHE_AWS_ACCESS_KEY_ID }}
@@ -221,8 +221,8 @@ jobs:
     runs-on: windows-latest
     env:
       RUSTC_WRAPPER: sccache
-      SCCACHE_BUCKET: ${{ vars.SCCACHE_BUCKET }}
-      SCCACHE_ENDPOINT: ${{ vars.SCCACHE_ENDPOINT }}
+      SCCACHE_BUCKET: ${{ secrets.SCCACHE_BUCKET }}
+      SCCACHE_ENDPOINT: ${{ secrets.SCCACHE_ENDPOINT }}
       SCCACHE_REGION: auto
       SCCACHE_S3_USE_SSL: "true"
       AWS_ACCESS_KEY_ID: ${{ secrets.SCCACHE_AWS_ACCESS_KEY_ID }}
@@ -273,8 +273,8 @@ jobs:
     runs-on: macOS-latest
     env:
       RUSTC_WRAPPER: sccache
-      SCCACHE_BUCKET: ${{ vars.SCCACHE_BUCKET }}
-      SCCACHE_ENDPOINT: ${{ vars.SCCACHE_ENDPOINT }}
+      SCCACHE_BUCKET: ${{ secrets.SCCACHE_BUCKET }}
+      SCCACHE_ENDPOINT: ${{ secrets.SCCACHE_ENDPOINT }}
       SCCACHE_REGION: auto
       SCCACHE_S3_USE_SSL: "true"
       AWS_ACCESS_KEY_ID: ${{ secrets.SCCACHE_AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -91,11 +91,21 @@ jobs:
     permissions:
       contents: read
       deployments: write
+    env:
+      RUSTC_WRAPPER: sccache
+      SCCACHE_BUCKET: ${{ vars.SCCACHE_BUCKET }}
+      SCCACHE_ENDPOINT: ${{ vars.SCCACHE_ENDPOINT }}
+      SCCACHE_REGION: auto
+      SCCACHE_S3_USE_SSL: "true"
+      AWS_ACCESS_KEY_ID: ${{ secrets.SCCACHE_AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.SCCACHE_AWS_SECRET_ACCESS_KEY }}
 
     steps:
       - uses: actions/checkout@v4
         with:
           lfs: ${{ env.use_git_lfs }}
+      - name: Set up sccache
+        uses: mozilla-actions/sccache-action@v0.0.9
       - name: Cache Rust dependencies
         uses: actions/cache@v4
         with:
@@ -147,17 +157,30 @@ jobs:
           else
             echo "Skipping verification (no URL matched)"
           fi
+      - name: Show sccache stats
+        if: always()
+        run: sccache --show-stats
 
   # Build for Linux
   release-linux:
     needs: pre-release-check
     if: needs.pre-release-check.outputs.should_release == 'true'
     runs-on: ubuntu-latest
+    env:
+      RUSTC_WRAPPER: sccache
+      SCCACHE_BUCKET: ${{ vars.SCCACHE_BUCKET }}
+      SCCACHE_ENDPOINT: ${{ vars.SCCACHE_ENDPOINT }}
+      SCCACHE_REGION: auto
+      SCCACHE_S3_USE_SSL: "true"
+      AWS_ACCESS_KEY_ID: ${{ secrets.SCCACHE_AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.SCCACHE_AWS_SECRET_ACCESS_KEY }}
 
     steps:
       - uses: actions/checkout@v4
         with:
           lfs: ${{ env.use_git_lfs }}
+      - name: Set up sccache
+        uses: mozilla-actions/sccache-action@v0.0.9
       - name: Cache Rust dependencies
         uses: actions/cache@v4
         with:
@@ -187,17 +210,30 @@ jobs:
           path: ${{ env.binary }}-linux-${{ needs.pre-release-check.outputs.version }}.zip
           name: linux
           retention-days: 1
+      - name: Show sccache stats
+        if: always()
+        run: sccache --show-stats
 
   # Build for Windows
   release-windows:
     needs: pre-release-check
     if: needs.pre-release-check.outputs.should_release == 'true'
     runs-on: windows-latest
+    env:
+      RUSTC_WRAPPER: sccache
+      SCCACHE_BUCKET: ${{ vars.SCCACHE_BUCKET }}
+      SCCACHE_ENDPOINT: ${{ vars.SCCACHE_ENDPOINT }}
+      SCCACHE_REGION: auto
+      SCCACHE_S3_USE_SSL: "true"
+      AWS_ACCESS_KEY_ID: ${{ secrets.SCCACHE_AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.SCCACHE_AWS_SECRET_ACCESS_KEY }}
 
     steps:
       - uses: actions/checkout@v4
         with:
           lfs: ${{ env.use_git_lfs }}
+      - name: Set up sccache
+        uses: mozilla-actions/sccache-action@v0.0.9
       - name: Cache Rust dependencies
         uses: actions/cache@v4
         with:
@@ -226,17 +262,30 @@ jobs:
           path: ${{ env.binary }}-windows-${{ needs.pre-release-check.outputs.version }}.zip
           name: windows
           retention-days: 1
+      - name: Show sccache stats
+        if: always()
+        run: sccache --show-stats
 
   # Build for MacOS Apple Silicon
   release-macOS-apple-silicon:
     needs: pre-release-check
     if: needs.pre-release-check.outputs.should_release == 'true'
     runs-on: macOS-latest
+    env:
+      RUSTC_WRAPPER: sccache
+      SCCACHE_BUCKET: ${{ vars.SCCACHE_BUCKET }}
+      SCCACHE_ENDPOINT: ${{ vars.SCCACHE_ENDPOINT }}
+      SCCACHE_REGION: auto
+      SCCACHE_S3_USE_SSL: "true"
+      AWS_ACCESS_KEY_ID: ${{ secrets.SCCACHE_AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.SCCACHE_AWS_SECRET_ACCESS_KEY }}
 
     steps:
       - uses: actions/checkout@v4
         with:
           lfs: ${{ env.use_git_lfs }}
+      - name: Set up sccache
+        uses: mozilla-actions/sccache-action@v0.0.9
       - name: Cache Rust dependencies
         uses: actions/cache@v4
         with:
@@ -265,6 +314,9 @@ jobs:
           path: ${{ env.binary }}-macOS-apple-silicon-${{ needs.pre-release-check.outputs.version }}.dmg
           name: macOS-apple-silicon
           retention-days: 1
+      - name: Show sccache stats
+        if: always()
+        run: sccache --show-stats
   release:
     permissions:
       actions: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,9 +24,19 @@ jobs:
     name: Test Suite on Linux AMD64 Ubuntu
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    env:
+      RUSTC_WRAPPER: sccache
+      SCCACHE_BUCKET: ${{ vars.SCCACHE_BUCKET }}
+      SCCACHE_ENDPOINT: ${{ vars.SCCACHE_ENDPOINT }}
+      SCCACHE_REGION: auto
+      SCCACHE_S3_USE_SSL: "true"
+      AWS_ACCESS_KEY_ID: ${{ secrets.SCCACHE_AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.SCCACHE_AWS_SECRET_ACCESS_KEY }}
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
+      - name: Set up sccache
+        uses: mozilla-actions/sccache-action@v0.0.9
       - name: Cache
         uses: actions/cache@v4
         with:
@@ -54,14 +64,27 @@ jobs:
         with:
           github-token: ${{ secrets.COPILOT_INVOKER_TOKEN }}
           job-name: "Test Suite on Linux AMD64 Ubuntu"
+      - name: Show sccache stats
+        if: always()
+        run: sccache --show-stats
 
   test-macos:
     name: Test Suite on MacOS
     runs-on: macOS-latest
     timeout-minutes: 30
+    env:
+      RUSTC_WRAPPER: sccache
+      SCCACHE_BUCKET: ${{ vars.SCCACHE_BUCKET }}
+      SCCACHE_ENDPOINT: ${{ vars.SCCACHE_ENDPOINT }}
+      SCCACHE_REGION: auto
+      SCCACHE_S3_USE_SSL: "true"
+      AWS_ACCESS_KEY_ID: ${{ secrets.SCCACHE_AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.SCCACHE_AWS_SECRET_ACCESS_KEY }}
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
+      - name: Set up sccache
+        uses: mozilla-actions/sccache-action@v0.0.9
       - name: Cache
         uses: actions/cache@v4
         with:
@@ -87,15 +110,28 @@ jobs:
         with:
           github-token: ${{ secrets.COPILOT_INVOKER_TOKEN }}
           job-name: "Test Suite on MacOS"
+      - name: Show sccache stats
+        if: always()
+        run: sccache --show-stats
 
   # Run cargo clippy -- -D warnings
   clippy_check:
     name: Clippy
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    env:
+      RUSTC_WRAPPER: sccache
+      SCCACHE_BUCKET: ${{ vars.SCCACHE_BUCKET }}
+      SCCACHE_ENDPOINT: ${{ vars.SCCACHE_ENDPOINT }}
+      SCCACHE_REGION: auto
+      SCCACHE_S3_USE_SSL: "true"
+      AWS_ACCESS_KEY_ID: ${{ secrets.SCCACHE_AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.SCCACHE_AWS_SECRET_ACCESS_KEY }}
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
+      - name: Set up sccache
+        uses: mozilla-actions/sccache-action@v0.0.9
       - name: Cache
         uses: actions/cache@v4
         with:
@@ -122,6 +158,9 @@ jobs:
         with:
           github-token: ${{ secrets.COPILOT_INVOKER_TOKEN }}
           job-name: "Clippy"
+      - name: Show sccache stats
+        if: always()
+        run: sccache --show-stats
 
   # Run cargo fmt --all -- --check
   format:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,8 +26,8 @@ jobs:
     timeout-minutes: 30
     env:
       RUSTC_WRAPPER: sccache
-      SCCACHE_BUCKET: ${{ vars.SCCACHE_BUCKET }}
-      SCCACHE_ENDPOINT: ${{ vars.SCCACHE_ENDPOINT }}
+      SCCACHE_BUCKET: ${{ secrets.SCCACHE_BUCKET }}
+      SCCACHE_ENDPOINT: ${{ secrets.SCCACHE_ENDPOINT }}
       SCCACHE_REGION: auto
       SCCACHE_S3_USE_SSL: "true"
       AWS_ACCESS_KEY_ID: ${{ secrets.SCCACHE_AWS_ACCESS_KEY_ID }}
@@ -74,8 +74,8 @@ jobs:
     timeout-minutes: 30
     env:
       RUSTC_WRAPPER: sccache
-      SCCACHE_BUCKET: ${{ vars.SCCACHE_BUCKET }}
-      SCCACHE_ENDPOINT: ${{ vars.SCCACHE_ENDPOINT }}
+      SCCACHE_BUCKET: ${{ secrets.SCCACHE_BUCKET }}
+      SCCACHE_ENDPOINT: ${{ secrets.SCCACHE_ENDPOINT }}
       SCCACHE_REGION: auto
       SCCACHE_S3_USE_SSL: "true"
       AWS_ACCESS_KEY_ID: ${{ secrets.SCCACHE_AWS_ACCESS_KEY_ID }}
@@ -121,8 +121,8 @@ jobs:
     timeout-minutes: 30
     env:
       RUSTC_WRAPPER: sccache
-      SCCACHE_BUCKET: ${{ vars.SCCACHE_BUCKET }}
-      SCCACHE_ENDPOINT: ${{ vars.SCCACHE_ENDPOINT }}
+      SCCACHE_BUCKET: ${{ secrets.SCCACHE_BUCKET }}
+      SCCACHE_ENDPOINT: ${{ secrets.SCCACHE_ENDPOINT }}
       SCCACHE_REGION: auto
       SCCACHE_S3_USE_SSL: "true"
       AWS_ACCESS_KEY_ID: ${{ secrets.SCCACHE_AWS_ACCESS_KEY_ID }}


### PR DESCRIPTION
## Summary
- use sccache action v0.0.9 in CI and build workflows
- configure R2-backed sccache env vars and show stats per job

## Testing
- not run (CI only)